### PR TITLE
Point gr-fosphor to freetype's include dir

### DIFF
--- a/gr-fosphor.rb
+++ b/gr-fosphor.rb
@@ -17,6 +17,7 @@ class GrFosphor < Formula
       args = %W[
         -DCMAKE_SHARED_LINKER_FLAGS='-Wl,-undefined,dynamic_lookup'
         -DPYTHON_LIBRARY='#{HOMEBREW_PREFIX}/lib/libgnuradio-runtime.dylib'
+        -DFREETYPE2_INCLUDE_DIR_ftheader='#{Formula["freetype"].include}'
       ] + std_cmake_args
       args << "-DENABLE_QT=ON" if build.with? "qt"
 


### PR DESCRIPTION
I had to take a mulligan on that last PR. I didn't realize `brew tap` only did a shallow clone and messed everything up.

I made the change you suggested in the last PR. `gr-osmosdr` still doesn't build because it can't find the Cheetah python library. I know gnuradio has it, but I still don't know homebrew's best practices about dealing with that. So for this PR I'm only targeting getting `gr-fosphor` to build.

`gnuradio-companion` still doesn't know about `gr-fosphor`, since it's not in GRC's block path. Is there a clean way to address that? Or at least print out the path to `gr-fosphor` and add message to add it GRC's block path?
