### PR TITLE
Do HEAD install for gr-iqbal

### DIFF
--- a/gr-iqbal.rb
+++ b/gr-iqbal.rb
@@ -1,7 +1,5 @@
 class GrIqbal < Formula
   homepage "http://www.osmocom.org/"
-  url "http://git.osmocom.org/gr-iqbal/snapshot/gr-iqbal-0.37.2.tar.xz"
-  sha256 "933d047e5be51020bc9a15386ddea7870103fb080c249af8aedf2dd4f1b499b2"
   head "git://git.osmocom.org/gr-iqbal"
 
   depends_on "cmake" => :build
@@ -33,7 +31,7 @@ __END__
 @@ -31,7 +31,7 @@
  		__GNUC_PATCHLEVEL__	\
  	)
- 
+
 -#if GCC_VERSION >= 40800
 +#if GCC_VERSION >= 40800 || defined(__clang__)
  # define complex _Complex


### PR DESCRIPTION
`gr-iqbal` depends on git submodule `libosmo-dsp`. The only way I could get it to work is by building HEAD. I'd prefer to to just download the tarball of `libosmo-dsp`, but I can't find a way to do that in a homebrew formula. Creating a sperate formula for `libosmo-dsp` doesn't appear to be an option, since `gr-iqbal` is actually using source files from `libosmo-dsp`.

This is the last fix needed to get `gr-osmosdr` to build.
