### PR TITLE
Add formula for Inspectrum, change liquid-dsp formula to build versio…

### DIFF
--- a/inspectrum.rb
+++ b/inspectrum.rb
@@ -1,0 +1,17 @@
+class Inspectrum < Formula
+  homepage "https://github.com/miek/inspectrum"
+  head "https://github.com/miek/inspectrum.git"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "qt5"
+  depends_on "fftw"
+  depends_on "liquid-dsp"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+end

--- a/liquid-dsp.rb
+++ b/liquid-dsp.rb
@@ -3,46 +3,19 @@ require "formula"
 class LiquidDsp < Formula
   homepage "http://liquidsdr.org/"
   head "https://github.com/jgaeddert/liquid-dsp.git"
-  url "https://github.com/jgaeddert/liquid-dsp/archive/v1.2.0.tar.gz"
-  sha1 "79bd76e0844778a16459e8cd8da747c87bd951fd"
+  # inspectrum needs a recent version of liquid-dsp and the latest release is from 2012.
+  url "https://github.com/jgaeddert/liquid-dsp.git", :revision => "1191179b786703b3af20abf7e1404d91099b335d"
 
   depends_on "fftw"
-  head do
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-    depends_on "pkg-config" => :build
-  end
-  stable do
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
-
-  patch :DATA if build.stable?
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
 
   def install
-    system "./bootstrap.sh" if build.head?
-    system "./reconf" if build.stable?
+    system "./bootstrap.sh"
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end
 end
-
-__END__
-diff -aur liquid-dsp-1.2.0.orig/configure.ac liquid-dsp-1.2.0/configure.ac
---- liquid-dsp-1.2.0.orig/configure.ac	2015-10-04 20:21:26.000000000 +0200
-+++ liquid-dsp-1.2.0/configure.ac	2015-10-04 20:22:57.000000000 +0200
-@@ -158,12 +158,6 @@
- AC_FUNC_MALLOC
- AC_FUNC_REALLOC
- # AC_CHECK_LIB (library, function, [action-if-found], [action-if-not-found], [other-libraries])
--AC_CHECK_LIB([c], [malloc, realloc, free, memset, memmove], [],
--             [AC_MSG_ERROR(Need standard c library!)],
--             [])
--AC_CHECK_LIB([m], [sinf, cosf, expf, cargf, cexpf, crealf, cimagf, sqrtf], [],
--             [AC_MSG_ERROR(Need standard (complex) math library!)],
--             [])
- 
- # Check for necessary header files
- AC_CHECK_HEADERS([stdio.h stdlib.h complex.h string.h getopt.h sys/resource.h float.h inttypes.h limits.h stdlib.h string.h unistd.h])


### PR DESCRIPTION
…n new enough for inspectrum.

I simply picked the revision that is currently master for liquid-dsp. Looks like they stopped tagging releases a long time ago.

I built cubicsdr against the new liquid-dsp, and basic functionality (tuning, waterfall, FM demod) seem to work.
