### PR TITLE
Add gr-foo

### DIFF
--- a/gr-foo.rb
+++ b/gr-foo.rb
@@ -1,0 +1,24 @@
+class GrFoo < Formula
+  homepage "https://github.com/bastibl/gr-foo"
+  head "https://github.com/bastibl/gr-foo.git"
+
+  depends_on "cmake" => :build
+  depends_on "swig" => :build
+  depends_on "gnuradio"
+  depends_on "boost"
+  depends_on "cppunit"
+
+  def install
+    mkdir "build" do
+      ENV.append "LDFLAGS", "-Wl,-undefined,dynamic_lookup"
+      # Point Python library to existing path or CMake test will fail.
+      args = %W[
+        -DCMAKE_SHARED_LINKER_FLAGS='-Wl,-undefined,dynamic_lookup'
+        -DPYTHON_LIBRARY='#{HOMEBREW_PREFIX}/lib/libgnuradio-runtime.dylib'
+      ] + std_cmake_args
+
+      system "cmake", "..", *args
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
Add's bastibl's [gr-foo](https://github.com/bastibl/gr-foo) blocks

Had to install this for the gr-ieee802-15-4 examples foo_burst_tagger, also used by gr-ieee802-11
