### PR TITLE
Updated git url for gr-gsm.rb to v0.42.2

### DIFF
--- a/gr-gsm.rb
+++ b/gr-gsm.rb
@@ -2,7 +2,7 @@ class GrGsm < Formula
   desc "GNU Radio block for receiving GSM transmissions"
   homepage "https://github.com/ptrkrysik/gr-gsm"
   url "https://github.com/ptrkrysik/gr-gsm/archive/v0.42.2.tar.gz"
-  sha256 "6eb112014f20a93dbd4a447415a9702d4caa0fa87a4836d31d4628bc4056f73e"
+  sha256 "6127f87c1d295463c607a27cc2fc560e7a2b8684c1b0be10256db06936769976"
   head "https://github.com/ptrkrysik/gr-gsm.git"
 
   depends_on "cmake" => :build

--- a/gr-gsm.rb
+++ b/gr-gsm.rb
@@ -1,7 +1,7 @@
 class GrGsm < Formula
   desc "GNU Radio block for receiving GSM transmissions"
   homepage "https://github.com/ptrkrysik/gr-gsm"
-  url "https://github.com/ptrkrysik/gr-gsm/archive/0.41.4git.tar.gz"
+  url "https://github.com/ptrkrysik/gr-gsm/archive/v0.42.2.tar.gz"
   sha256 "6eb112014f20a93dbd4a447415a9702d4caa0fa87a4836d31d4628bc4056f73e"
   head "https://github.com/ptrkrysik/gr-gsm.git"
 


### PR DESCRIPTION
Was getting a 404 on the current git url version.

```└─[$] <> brew install dholm/sdr/gr-gsm
==> Installing gr-gsm from dholm/sdr
==> Downloading https://github.com/ptrkrysik/gr-gsm/archive/0.41.4git.tar.gz
==> Downloading from https://codeload.github.com/ptrkrysik/gr-gsm/tar.gz/0.41.4git

curl: (22) The requested URL returned error: 404 Not Found
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "gr-gsm"
Download failed: https://github.com/ptrkrysik/gr-gsm/archive/0.41.4git.tar.gz```